### PR TITLE
Add breaking mobile-first test

### DIFF
--- a/tests/acceptance/mobile-first-test.js
+++ b/tests/acceptance/mobile-first-test.js
@@ -1,0 +1,51 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import Ember from 'ember';
+
+function getOwner(context) {
+  return context.application.__deprecatedInstance__ || context.application.__container__;
+}
+
+const {
+  run
+  } = Ember;
+
+moduleForAcceptance('Acceptance | mobile-first', {
+  beforeEach(assert) {
+    assert.deviceLayout = getOwner(this).lookup('service:device/layout');
+  }
+});
+
+test('visiting /tests/mobile-first', function(assert) {
+  visit('/tests/mobile-first');
+  let { deviceLayout } = assert;
+  let breakpoints = deviceLayout.get('breakpoints');
+  let bp = {};
+  breakpoints.forEach(function(point) {
+    bp[point.name] = point.begin + 5;
+  });
+
+  deviceLayout.set('width', bp.mobile);
+
+  andThen(function() {
+    assert.equal(currentURL(), '/tests/mobile-first');
+
+    assert.equal(find('h1.layout-test').text(), 'Mobile!', `The layout renders the mobile layout when width is ${bp.mobile}`);
+    run(() => {
+      deviceLayout.set('width', bp.tablet);
+    });
+
+    andThen(() => {
+      assert.equal(find('h1.layout-test').text(), 'Mobile!', `The layout still renders the mobile layout when width is ${bp.tablet} (no tablet layout defined)`);
+      run(() => {
+        deviceLayout.set('width', bp.desktop);
+      });
+
+      andThen(() => {
+        assert.equal(find('h1.layout-test').text(), 'Desktop!', `The layout renders the desktop layout when width is ${bp.desktop}`);
+
+      });
+    });
+
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
     this.route('layouts');
     this.route('sustain');
     this.route('sustain-b');
+    this.route('mobile-first');
   });
 
   this.route('docs', function() {

--- a/tests/dummy/app/routes/tests/mobile-first/-layouts/desktop.hbs
+++ b/tests/dummy/app/routes/tests/mobile-first/-layouts/desktop.hbs
@@ -1,0 +1,5 @@
+<page class="bg-orange">
+  <centered>
+    <h1 class="layout-test text-center">Desktop!</h1>
+  </centered>
+</page>

--- a/tests/dummy/app/routes/tests/mobile-first/-layouts/mobile.hbs
+++ b/tests/dummy/app/routes/tests/mobile-first/-layouts/mobile.hbs
@@ -1,0 +1,5 @@
+<page class="bg-orange">
+  <centered>
+    <h1 class="layout-test text-center">Mobile!</h1>
+  </centered>
+</page>

--- a/tests/dummy/app/routes/tests/mobile-first/route.js
+++ b/tests/dummy/app/routes/tests/mobile-first/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});


### PR DESCRIPTION
This demonstrates how a larger breakpoint layout (desktop) is rendered when a
smaller layout (mobile) should be rendered to follow the mobile-first paradigm.

Note that in this example the active breakpoint (tablet) has no layout defined.