### PR TITLE
Fix sustain to work with classic app structure.

### DIFF
--- a/addon/lib/sustain.js
+++ b/addon/lib/sustain.js
@@ -223,7 +223,11 @@ export default Obj.extend({
     // pre Ember 2.0, layout is a computed property that MUST be set
     // via get/set
     if (!this._component.get('layout')) {
-      this._component.set('layout', this.owner.lookup(`template:${name}`));
+      let template = this.owner.lookup(`template:${name}`);
+      if (!template) {
+        template = this.owner.lookup(`template:components/${name}`);
+      }
+      this._component.set('layout', template);
     }
     this._component.set('model', model);
 

--- a/tests/acceptance/sustain-classic-component-test.js
+++ b/tests/acceptance/sustain-classic-component-test.js
@@ -1,0 +1,14 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | sustain classic');
+
+test('visiting /tests/sustain-classic-component', function(assert) {
+  visit('/tests/sustain-classic-component');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/tests/sustain-classic-component', 'We transitioned to the initial route');
+
+    assert.equal(find('h2.classic-component').eq(0).text(), 'Classic Component', 'We rendered the sustain');
+  });
+});

--- a/tests/dummy/app/components/classic-component.js
+++ b/tests/dummy/app/components/classic-component.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend();

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -17,6 +17,7 @@ Router.map(function() {
     this.route('sustain-labels');
     this.route('sustain-labels-2');
     this.route('sustain-hooks');
+    this.route('sustain-classic-component');
   });
 
   this.route('docs', function() {

--- a/tests/dummy/app/routes/tests/sustain-classic-component/route.js
+++ b/tests/dummy/app/routes/tests/sustain-classic-component/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/tests/sustain-classic-component/template.hbs
+++ b/tests/dummy/app/routes/tests/sustain-classic-component/template.hbs
@@ -1,0 +1,1 @@
+{{sustain 'classic-component'}}

--- a/tests/dummy/app/templates/components/classic-component.hbs
+++ b/tests/dummy/app/templates/components/classic-component.hbs
@@ -1,0 +1,1 @@
+<h2 class="classic-component">Classic Component</h2>


### PR DESCRIPTION
A classic app structure has components templates in the templates/components folder.

Fallback to look up via classic structure if the template isn't initially found.