### PR TITLE
fix(styles): remove horizontal scrollbar

### DIFF
--- a/addon/styles/components/_page.scss
+++ b/addon/styles/components/_page.scss
@@ -7,7 +7,6 @@
 
     // avoid using width directly
     max-width: 100vw;
-    min-width: 100vw;
     min-height: 100vh;
   }
 }


### PR DESCRIPTION
Hey @runspired! Big fan of the framework, just had a small fix when using `<page>`. Below are examples:

<img width="1440" alt="screen shot 2016-05-02 at 1 18 37 pm" src="https://cloud.githubusercontent.com/assets/914228/14961630/81247584-1068-11e6-93d7-563ef06c406e.png">

<img width="1440" alt="screen shot 2016-05-02 at 1 18 40 pm" src="https://cloud.githubusercontent.com/assets/914228/14961633/826af440-1068-11e6-8b48-474132671893.png">