### PR TITLE
breaking tests for sustain hook double-fires

### DIFF
--- a/tests/acceptance/sustain-hooks-test.js
+++ b/tests/acceptance/sustain-hooks-test.js
@@ -17,13 +17,13 @@ test('Testing sustain-hooks', function(assert) {
     let registry = this.application.__container__.lookup('-view-registry:main') || Ember.View.views;
     let component = registry['sustain-hooks-test'];
 
-    assert.ok(component.get('didMoveTriggered'), 'didMove triggers on initial insert');
-    assert.ok(component.get('didMoveEvent'), 'didMove event triggers on initial insert');
+    assert.equal(component.get('didMoveTriggeredCount'), 1, 'didMove triggers on initial insert');
+    assert.equal(component.get('didMoveEventCount'), 1, 'didMove event triggers on initial insert');
 
-    assert.notOk(component.get('willMoveTriggered'), 'willMove does not trigger on initial insert');
-    assert.notOk(component.get('willMoveEvent'), 'willMove event does not trigger on initial insert');
+    assert.equal(component.get('willMoveTriggeredCount'), 0, 'willMove does not trigger on initial insert');
+    assert.equal(component.get('willMoveEventCount'), 0, 'willMove event does not trigger on initial insert');
 
-    assert.ok(component.get('insertTriggered'), 'didInsertElement properly triggers its super');
+    assert.equal(component.get('insertTriggeredCount'), 1, 'didInsertElement properly triggers its super');
 
     let controller = this.application.__container__.lookup('controller:tests/sustain-hooks');
 
@@ -32,8 +32,8 @@ test('Testing sustain-hooks', function(assert) {
     });
 
     andThen(() => {
-      assert.ok(component.get('willMoveTriggered'), 'willMove triggers when leaving a location');
-      assert.ok(component.get('willMoveEvent'), 'willMove event triggers when leaving a location');
+      assert.equal(component.get('willMoveTriggeredCount'), 1, 'willMove triggers when leaving a location');
+      assert.equal(component.get('willMoveEventCount'), 1, 'willMove event triggers when leaving a location');
     });
   });
 });

--- a/tests/dummy/app/routes/tests/sustain-hooks/has-hooks/component.js
+++ b/tests/dummy/app/routes/tests/sustain-hooks/has-hooks/component.js
@@ -8,32 +8,32 @@ const {
 export default Component.extend({
   elementId: 'sustain-hooks-test',
 
-  insertTriggered: false,
-  willMoveTriggered: false,
-  didMoveTriggered: false,
+  insertTriggeredCount: 0,
+  willMoveTriggeredCount: 0,
+  didMoveTriggeredCount: 0,
 
-  willMoveEvent: false,
-  didMoveEvent: false,
+  willMoveEventCount: 0,
+  didMoveEventCount: 0,
 
   didMove() {
-    this.set('didMoveTriggered', true);
+    this.incrementProperty('didMoveTriggeredCount');
   },
 
   willMove() {
-    this.set('willMoveTriggered', true);
+    this.incrementProperty('willMoveTriggeredCount');
   },
 
   _onDidMove: on('didMove', function() {
-    this.set('didMoveEvent', true);
+    this.incrementProperty('didMoveEventCount');
   }),
 
   _onWillMove: on('willMove', function() {
-    this.set('willMoveEvent', true);
+    this.incrementProperty('willMoveEventCount');
   }),
 
   willInsertElement() {
     this._super();
-    this.set('insertTriggered', true);
+    this.incrementProperty('insertTriggeredCount');
   }
 
 });


### PR DESCRIPTION
I noticed that some of the sustain hooks were firing twice

![image](https://cloud.githubusercontent.com/assets/81818/15631025/eba4dd8c-2520-11e6-9574-6fa1d0734d26.png)

