### PR TITLE
Add missing defaultBlueprint field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "versionCompatibility": {
       "ember": ">=1.13.13"
     },
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "defaultBlueprint": "flexi"
   }
 }


### PR DESCRIPTION
Add missing defaultBlueprint, otherwise the flexi blueprint won't be executed during addon installations. Fixes #66