### PR TITLE
Guard addon/services/device/layout.js against FastBoot

### DIFF
--- a/addon/mixins/container.js
+++ b/addon/mixins/container.js
@@ -13,12 +13,13 @@ export default Mixin.create({
   inserted: false,
   classNameBindings: ['breakpointClass'],
   breakpointClass: computed('inserted', 'deviceLayout.width', function() {
+    let bps = this.get('deviceLayout.breakpoints');
+     
     if (!this.get('inserted')) {
-      return '';
+     return `container-${bps[0].prefix}`;
     }
 
     let width = this.element.clientWidth;
-    let bps = this.get('deviceLayout.breakpoints');
 
     for (let i = 0; i < bps.length; i++) {
       if (width >= bps[i].begin) {

--- a/addon/services/device/layout.js
+++ b/addon/services/device/layout.js
@@ -32,7 +32,10 @@ export default Service.extend({
 
   willDestroy() {
     this._super(...arguments);
-    window.removeEventListener('resize', this._resizeHandler, true);
+    
+    if (typeof window === 'object' && typeof document === 'object') {
+      window.removeEventListener('resize', this._resizeHandler, true);
+    }
   },
 
   updateResolution() {

--- a/addon/services/device/layout.js
+++ b/addon/services/device/layout.js
@@ -92,8 +92,11 @@ export default Service.extend({
     this._super();
 
     this.setupBreakpoints();
-    this.setupResize();
-    this.updateResolution();
+
+    if (typeof window === 'object' && typeof document === 'object') {
+      this.setupResize();
+      this.updateResolution();
+    }
   }
 
 });


### PR DESCRIPTION
```
There was an error running your app in fastboot. More info about the error:
 ReferenceError: document is not defined
    at [object Object].updateResolution (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:96102:24)
    at [object Object].init (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:96163:12)
    at [object Object].superWrapper [as init] (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:32362:22)
    at new Class (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:46161:14)
    at Function.ClassMixinProps.create (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:46432:14)
    at instantiate (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11574:23)
    at lookup (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11412:17)
    at buildInjections (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11451:36)
    at injectionsFor (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11524:22)
    at factoryFor (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11495:24)
    at Object.Container.lookupFactory (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11345:14)
    at [object Object].exports.default._emberMetalMixin.Mixin.create._lookupFactory (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:42707:33)
    at [object Object].<anonymous> (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:34978:67)
    at Descriptor.ComputedPropertyPrototype.get (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:24355:28)
    at Object.get (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:30009:19)
    at [object Object]._emberRuntimeSystemObject.default.extend._queryParamsFor (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:37597:46)
    at forEachQueryParam (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:38032:26)
    at [object Object]._emberRuntimeSystemObject.default.extend._deserializeQueryParams (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:37530:7)
    at getFullQueryParams (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:36847:12)
    at getQueryParamsFor (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:36859:27)
    at [object Object]._emberRuntimeSystemObject.default.extend.paramsFor (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:35174:41)
    at [object Object]._emberRuntimeSystemObject.default.extend.deserialize (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:36225:30)
    at Object.applyHook (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:61277:30)
    at Object.HandlerInfo.runSharedModelHook (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:59466:33)
    at Object._routerUtils.subclass.getModel (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:59382:19)
    at i (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:61145:17)
    at tryCatch (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:61492:14)
    at invokeCallback (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:61507:15)
    at publish (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:61475:9)
    at /Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:41377:7
    at Queue.invokeWithOnError (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:10417:18)
    at Object.Queue.flush (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:10472:11)
    at Object.DeferredActionQueues.flush (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:10280:17)
    at Object.Backburner.end (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:10635:25)
    at [object Object]._onTimeout (/Users/thoov/Documents/nest/store/dist/public/fastboot/vendor.js:11201:18)
    at Timer.listOnTimeout (timers.js:92:15)
```