### PR TITLE
make sure offset classes are displayed correctly

### DIFF
--- a/addon/styles/grid/_mixins.scss
+++ b/addon/styles/grid/_mixins.scss
@@ -90,7 +90,7 @@
       // offsets
       @for $i from 0 through ($columns - 1) {
         @if $breakpoint-counter != 1 or $i != 0 { // Avoid emitting useless .col-xs-offset-0
-          .offset-#{$bp-prefix}-#{$i} {
+          .#{$col-prefix}offset-#{$bp-prefix}-#{$i} {
             margin-left: percentage($i / $columns);
           }
         }

--- a/dsl/dsl-defaults.js
+++ b/dsl/dsl-defaults.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   generateOffsetClass: function(breakpoint, colNumber, columnPrefix /*, totalColumns*/) {
-    return (columnPrefix ? columnPrefix + "-" : "") + breakpoint.prefix + "-offset-" + colNumber;
+    return (columnPrefix ? columnPrefix + "-" : "") + "offset-" + breakpoint.prefix + "-" + colNumber;
   },
 
   /*


### PR DESCRIPTION
1. Offsets were being generated without a column prefix
2. The ordering of `generateOffsetClass` was a bit off from what's generated in the scss