### PR TITLE
fix(deprecation): provide a caching strategy

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,17 +81,20 @@ module.exports = {
     registry.add('htmlbars-ast-plugin', {
       name: "flexi-attribute-conversion",
       before: "flexi-component-conversion",
-      plugin: AttributeConversion
+      plugin: AttributeConversion,
+      baseDir: function() { return __dirname }
     });
 
     registry.add('htmlbars-ast-plugin', {
       name: "flexi-component-conversion",
-      plugin: ComponentConversion
+      plugin: ComponentConversion,
+      baseDir: function() { return __dirname }
     });
 
     registry.add('htmlbars-ast-plugin', {
       name: "flexi-sustain-conversion",
-      plugin: SustainConversion
+      plugin: SustainConversion,
+      baseDir: function() { return __dirname }
     });
 
   },


### PR DESCRIPTION
I've been getting these deprecation warnings upon starting my project:

```
DEPRECATION: ember-cli-htmlbars-inline-precompile is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-attribute-conversion`.
DEPRECATION: ember-cli-htmlbars-inline-precompile is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-component-conversion`.
DEPRECATION: ember-cli-htmlbars-inline-precompile is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-sustain-conversion`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-attribute-conversion`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-component-conversion`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-sustain-conversion`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-attribute-conversion`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-component-conversion`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `flexi-sustain-conversion`.
```

Here's my `ember -v` info:

```
ember-cli: 2.7.0
node: 4.2.2
os: darwin x64
```

Apparently the fixes mentioned in https://github.com/ember-animation/liquid-fire/issues/485 also fix the warnings here. 😮 