### PR TITLE
Add addon.sass to works with sass/scss

### DIFF
--- a/addon/styles/addon.sass
+++ b/addon/styles/addon.sass
@@ -1,0 +1,6 @@
+@import 'variables'
+
+@import 'mixins/index'
+@import 'grid/grid'
+@import 'helpers/index'
+@import 'components/index'


### PR DESCRIPTION
See #80 When my app have `.sass` the flexi not working because `ember-cli-sass` not avoid the propagate configuration to addons.